### PR TITLE
cleankill: added interrupting client listener

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGClientListener.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGClientListener.java
@@ -8,4 +8,10 @@ public interface NGClientListener {
      * clientDisconnected throws an InterruptedException nailgun interrupts the main session thread.
      */
     public void clientDisconnected() throws InterruptedException;
+
+    public final class Interrupter implements  NGClientListener {
+        public void clientDisconnected() throws InterruptedException {
+            throw new InterruptedException();
+        }
+    }
 }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -248,7 +248,10 @@ public class NGSession extends Thread {
                 PrintStream exit = null;
 
                 try {
-                    in = new NGInputStream(sockin, sockout, server.out, heartbeatTimeoutMillis);
+                    NGInputStream ngin = new NGInputStream(sockin, sockout, server.out, heartbeatTimeoutMillis);
+                    ngin.addClientListener(new NGClientListener.Interrupter());
+
+                    in = ngin;
                     out = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_STDOUT));
                     err = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_STDERR));
                     exit = new PrintStream(new NGOutputStream(sockout, NGConstants.CHUNKTYPE_EXIT));


### PR DESCRIPTION
Add an implementation of an NGClientListener that simply throws an InterruptedException, and add this to a session by default. This 'fixes' the behavior that a thread remains running after the client dies, but does not provide a way to only do this optionally

Reference: balihoo/nailgun#1
